### PR TITLE
Addition of build script for non-CSGO games

### DIFF
--- a/armagetron/build.sh
+++ b/armagetron/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t armagetron .

--- a/hl2dm/build.sh
+++ b/hl2dm/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t hl2dm .

--- a/steamcmd/build.sh
+++ b/steamcmd/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t steamcmd .

--- a/tf2-prophunt/build.sh
+++ b/tf2-prophunt/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t tf2-prophunt .

--- a/tf2/build.sh
+++ b/tf2/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build -t tf2 .


### PR DESCRIPTION
A change just to ensure consistency between games so that they all have consistent methods of being built.

All tags are currently based off the folder name naming method of
game-mod.
eg:
 tf2-prophunt

Happy to either ditch the build scripts for CSGO or add these, however I am all for the method of being built being the same between containers, also all for tags that help to identify games from docker ps quickly.