### PR TITLE
Fixing download users for csgo-warmod and tf2-prophunt

### DIFF
--- a/csgo-warmod/download.sh
+++ b/csgo-warmod/download.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-MMVERSION=$( curl http://www.metamodsource.net/downloads/ | grep -o "mmsource-[0-9\.]*-linux.tar.gz" | head -n 1 )
-curl -o $MMVERSION http://www.gsptalk.com/mirror/sourcemod/$MMVERSION
+MMVERSION=$( curl http://www.metamodsource.net/downloads.php | grep -o "mmsource-[0-9\.]*-git[0-9]\+-linux.tar.gz" | head -n 1 )
+
+MMMAJORVERSION=$(echo $MMVERSION | cut -d '-' -f 2 | cut -d '.' -f 1,2 )
+
+curl -o $MMVERSION https://mms.alliedmods.net/mmsdrop/$MMMAJORVERSION/$MMVERSION
 
 SMVERSION=$(  curl http://www.sourcemod.net/downloads.php?branch=stable | grep -Eo "sourcemod-.*?-linux.tar.gz" | head -n 1 )
 

--- a/tf2-prophunt/Dockerfile
+++ b/tf2-prophunt/Dockerfile
@@ -5,8 +5,6 @@ USER steam
 
 WORKDIR /steam/tf2/
 
-# Huge dep. Download every time or keep copy locally?
-#ADD https://github.com/powerlord/sourcemod-prophunt/releases/download/maps/PHMapEssentialsBZ2.7z .
 ADD PHMapEssentialsBZ2.7z  .
 
 # Don't forget they're .tar.gzs, so docker will try and be too smart for its own damed good

--- a/tf2-prophunt/build.sh
+++ b/tf2-prophunt/build.sh
@@ -6,8 +6,11 @@
 if [[ ! `ls mmsource-*-linux.tar.gz` ]]
 then
 
-	MMVERSION=$( curl http://www.metamodsource.net/downloads/ | grep -o "mmsource-[0-9\.]*-linux.tar.gz" | head -n 1 )
-	curl -o $MMVERSION http://www.gsptalk.com/mirror/sourcemod/$MMVERSION
+	MMVERSION=$( curl http://www.metamodsource.net/downloads.php | grep -o "mmsource-[0-9\.]*-git[0-9]\+-linux.tar.gz" | head -n 1 )
+	MMMAJORVERSION=$(echo $MMVERSION | cut -d '-' -f 2 | cut -d '.' -f 1,2 )
+
+	curl -o $MMVERSION https://mms.alliedmods.net/mmsdrop/$MMMAJORVERSION/$MMVERSION
+
 fi
 
 if [[ ! `ls sourcemod-*-linux.tar.gz` ]]
@@ -35,5 +38,7 @@ fi
 
 [[ -f prophuntredux.zip ]] || curl -o prophuntredux.zip "https://forums.alliedmods.net/attachment.php?attachmentid=146505&d=1441898056" || (echo "Coudln't download prophunt" && exit 1)
 [[ -f sm_observerpoint.smx ]] || curl -o sm_observerpoint.smx "http://www.sourcemod.net/vbcompiler.php?file_id=34433" || (echo "Coudln't download observerpoint" && exit 1)
+
+[[ -f PHMapEssentialsBZ2.7z ]] || curl -L -o PHMapEssentialsBZ2.7z "https://github.com/powerlord/sourcemod-prophunt/releases/download/maps/PHMapEssentialsBZ2.7z" || (echo "Coudln't download prophunt maps" && exit 1)
 
 docker_build tf2-prophunt

--- a/tf2-prophunt/download.sh
+++ b/tf2-prophunt/download.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-MMVERSION=$( curl http://www.metamodsource.net/downloads/ | grep -o "mmsource-[0-9\.]*-linux.tar.gz" | head -n 1 )
-curl -o $MMVERSION http://www.gsptalk.com/mirror/sourcemod/$MMVERSION
+MMVERSION=$( curl http://www.metamodsource.net/downloads.php | grep -o "mmsource-[0-9\.]*-git[0-9]\+-linux.tar.gz" | head -n 1 )
+
+MMMAJORVERSION=$(echo $MMVERSION | cut -d '-' -f 2 | cut -d '.' -f 1,2 )
+
+curl -o $MMVERSION https://mms.alliedmods.net/mmsdrop/$MMMAJORVERSION/$MMVERSION
 
 SMVERSION=$(  curl http://www.sourcemod.net/downloads.php?branch=stable | grep -Eo "sourcemod-.*?-linux.tar.gz" | head -n 1 )
 


### PR DESCRIPTION
Addressing https://github.com/OpenSourceLAN/gameservers-docker/issues/2

Updated the url that downloads mmsource and some additional commands to build the needed url since the updated url includes the major version. 

Also moved the downloading of prop hunt maps to build.sh. It checks if the maps already exist and downloads them if not. 