### PR TITLE
Starting Xvfb before wreckfest start script

### DIFF
--- a/wreckfest/Dockerfile
+++ b/wreckfest/Dockerfile
@@ -11,4 +11,4 @@ RUN ./steamcmd.sh +login anonymous +@sSteamCmdForcePlatformType windows +force_i
 
 WORKDIR /steam/wreckfest
 ADD start*.sh /steam/wreckfest/
-CMD ["./start-wreckfest.sh"]
+CMD ["Xvfb & DISPLAY=:0 ./start-wreckfest.sh"]

--- a/wreckfest/Dockerfile
+++ b/wreckfest/Dockerfile
@@ -11,4 +11,4 @@ RUN ./steamcmd.sh +login anonymous +@sSteamCmdForcePlatformType windows +force_i
 
 WORKDIR /steam/wreckfest
 ADD start*.sh /steam/wreckfest/
-CMD ["Xvfb & DISPLAY=:0 ./start-wreckfest.sh"]
+CMD ["./start-wreckfest.sh"]

--- a/wreckfest/start-wreckfest.sh
+++ b/wreckfest/start-wreckfest.sh
@@ -139,4 +139,5 @@ log=
 
 EOF
 
-exec wine server/Wreckfest.exe -s server_config=server_config.cfg
+/usr/bin/Xvfb &
+DISPLAY=:0 exec wine server/Wreckfest.exe -s server_config=server_config.cfg


### PR DESCRIPTION
Otherwise the container will exit with an error. This way it starts okay.